### PR TITLE
Fix typo on license line

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="ms.kataoka@gmail.com">Masaya Kataoka</maintainer>
 
-  <license>Apachi 2</license>
+  <license>Apache 2</license>
 
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
Noticed this generating ebuilds for Gentoo Linux with [superflore](https://github.com/ros-infrastructure/superflore).